### PR TITLE
fix version extraction to filter out non-numeric values (issue #1)

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,4 +10,4 @@ doc_fail() {
 [ -x "$(which curl)" ] || doc_fail "Missing the following dependency: curl"
 
 
-curl -s https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj/ | awk 'match($0, /<a href="[^.][^\/]+\/"/) { print substr( $0, RSTART+9, RLENGTH-11)}' | awk '{if (NR > 2) {printf "%s ", $0}}'
+curl -s https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj/ | awk 'match($0, /<a href="[^.][^\/]+\/"/) { print substr( $0, RSTART+9, RLENGTH-11)}' | awk '{if (NR > 2 && $0 ~ /^[0-9]/) {printf "%s ", $0}}'


### PR DESCRIPTION
Patch needed to filter out non-semver version (v1.6.0-RC.2) for mise (or asdf) to install current version 3.0.0 instead of 1.6.0-RC.2 